### PR TITLE
Validation added for Encrypt/decrypt message

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2009,13 +2009,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def do_encrypt(self, message_e, pubkey_e, encrypted_e):
         message = message_e.toPlainText()
-        message = message.encode('utf-8')
-        try:
-            encrypted = bitcoin.encrypt_message(message, pubkey_e.text())
-            encrypted_e.setText(encrypted.decode('ascii'))
-        except BaseException as e:
-            traceback.print_exc(file=sys.stdout)
-            self.show_warning(str(e))
+        if message=='':
+            self.show_message("Please enter message")
+        else:
+            message = message.encode('utf-8')
+            try:
+                encrypted = bitcoin.encrypt_message(message, pubkey_e.text())
+                encrypted_e.setText(encrypted.decode('ascii'))
+            except BaseException as e:
+                traceback.print_exc(file=sys.stdout)
+                self.show_warning("Invalid Public key")
 
     def encrypt_message(self, address=''):
         d = WindowModalDialog(self, _('Encrypt/decrypt Message'))


### PR DESCRIPTION
Blank Message and Incorrect/blank public key validation added for Encrypt/decrypt message window.

Please refer the following Github issues for description
Blank Message: [Fix #62](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/62)
Public Key: [Fix #64](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/64)

