### PR TITLE
Validation added for sign/verify

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1931,6 +1931,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def do_sign(self, address, message, signature, password):
         address  = address.text().strip()
         message = message.toPlainText().strip()
+        if message=='':
+            self.show_message("Please enter message")
+            return
         if not bitcoin.is_address(address):
             self.show_message('Invalid Feathercoin address.')
             return


### PR DESCRIPTION
Validation added for empty message field under sign/verify
Please refer bug [#60](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/60)