### PR TITLE
Removed max button disable code

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1109,7 +1109,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def reset_max(t):
             self.is_max = False
-            self.max_button.setEnabled(not bool(t))
         self.amount_e.textEdited.connect(reset_max)
         self.fiat_send_e.textEdited.connect(reset_max)
 


### PR DESCRIPTION
Removed the code used to disable the max button on amount requested text edit. Please refer the Bug [#32](https://github.com/Feathercoin-Foundation/electrum-ftc/issues/32) for detailed description
